### PR TITLE
Update setup_master.sh to fix node version error

### DIFF
--- a/tools/install_centos.sh
+++ b/tools/install_centos.sh
@@ -25,6 +25,7 @@ cd v2ray-panel
 wget https://github.com/losfair/IceCore/releases/download/v0.2.0/ice_core_linux.tar.xz
 xz -d < ice_core_linux.tar.xz | tar x
 cp dist/libice_core.so /usr/lib/
+cp dist/libice_core.so /usr/lib64/
 
 wget https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-x64.tar.xz
 xz -d < node-v8.2.1-linux-x64.tar.xz | tar x

--- a/tools/setup_master.sh
+++ b/tools/setup_master.sh
@@ -24,7 +24,7 @@ while true; do
     echo "The passwords DO NOT match, please try again."
 done
 
-uuid=$(node ./backend/cli.js -c $config_file register -u "$username" -p "$password")
+uuid=$(PWD=/usr/local/v2ray-panel/v2ray-Panel /usr/local/v2ray-panel/node/bin/node ./backend/cli.js -c $config_file register -u "$username" -p "$password")
 
 if  [ $? != 0 ]; then
     echo $uuid

--- a/tools/setup_master.sh
+++ b/tools/setup_master.sh
@@ -23,8 +23,8 @@ while true; do
     [ "$password" = "$password2" ] && break
     echo "The passwords DO NOT match, please try again."
 done
-
-uuid=$(PWD=/usr/local/v2ray-panel/v2ray-Panel /usr/local/v2ray-panel/node/bin/node ./backend/cli.js -c $config_file register -u "$username" -p "$password")
+cd /usr/local/v2ray-panel/v2ray-Panel 
+uuid=$(/usr/local/v2ray-panel/node/bin/node ./backend/cli.js -c $config_file register -u "$username" -p "$password")
 
 if  [ $? != 0 ]; then
     echo $uuid


### PR DESCRIPTION
When multiple node versions exists (especially on old systems like CentOS where the default node version is 6), the "node" command won't be able to use the correct node8 version. Therefore I patched the setup file to force setup.sh to use the node8 that has bundled during the installation.
Also a PWD env is set to make sure the script can be executed anywhere.