### PR TITLE
Make sure node8 was used during compiling

### DIFF
--- a/tools/install_centos.sh
+++ b/tools/install_centos.sh
@@ -42,7 +42,7 @@ chmod +x v2ray_patched
 git clone https://github.com/v2ray/v2ray-Panel
 cd v2ray-Panel
 
-export PATH+=:/usr/local/v2ray-panel/node/bin
+export "/usr/local/v2ray-panel/node/bin:"$PATH
 npm install --unsafe-perm
 
 mkdir /etc/v2ray-panel && cp config/*.json /etc/v2ray-panel/
@@ -50,7 +50,7 @@ mkdir /etc/v2ray-panel && cp config/*.json /etc/v2ray-panel/
 cat > /usr/local/bin/v2ray-panel-master << EOF
 
 #!/bin/bash
-export PATH+=:/usr/local/v2ray-panel/node/bin
+export "/usr/local/v2ray-panel/node/bin:"$PATH
 node /usr/local/v2ray-panel/v2ray-Panel/backend/main.js /etc/v2ray-panel/master.json
 
 EOF
@@ -58,7 +58,7 @@ EOF
 cat > /usr/local/bin/v2ray-panel-node << EOF
 
 #!/bin/bash
-export PATH+=:/usr/local/v2ray-panel/node/bin
+export "/usr/local/v2ray-panel/node/bin:"$PATH
 killall v2ray_patched | true
 node /usr/local/v2ray-panel/v2ray-Panel/backend/main.js /etc/v2ray-panel/node.json
 

--- a/tools/install_debian.sh
+++ b/tools/install_debian.sh
@@ -26,7 +26,7 @@ chmod +x v2ray_patched
 git clone https://github.com/v2ray/v2ray-Panel
 cd v2ray-Panel
 
-export PATH+=:/usr/local/v2ray-panel/node/bin
+export "/usr/local/v2ray-panel/node/bin:"$PATH
 npm install --unsafe-perm
 
 mkdir /etc/v2ray-panel && cp config/*.json /etc/v2ray-panel/
@@ -34,7 +34,7 @@ mkdir /etc/v2ray-panel && cp config/*.json /etc/v2ray-panel/
 cat > /usr/local/bin/v2ray-panel-master << EOF
 
 #!/bin/bash
-export PATH+=:/usr/local/v2ray-panel/node/bin
+export "/usr/local/v2ray-panel/node/bin:"$PATH
 node /usr/local/v2ray-panel/v2ray-Panel/backend/main.js /etc/v2ray-panel/master.json
 
 EOF
@@ -42,7 +42,7 @@ EOF
 cat > /usr/local/bin/v2ray-panel-node << EOF
 
 #!/bin/bash
-export PATH+=:/usr/local/v2ray-panel/node/bin
+export "/usr/local/v2ray-panel/node/bin:"$PATH
 killall v2ray_patched | true
 node /usr/local/v2ray-panel/v2ray-Panel/backend/main.js /etc/v2ray-panel/node.json
 

--- a/tools/setup_master.sh
+++ b/tools/setup_master.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PATH+=:/usr/local/v2ray-panel/node/bin
+export "/usr/local/v2ray-panel/node/bin:"$PATH
 
 config_file=/etc/v2ray-panel/master.json
 

--- a/tools/setup_node.sh
+++ b/tools/setup_node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PATH+=:/usr/local/v2ray-panel/node/bin
+export "/usr/local/v2ray-panel/node/bin:"$PATH
 
 config_file=/etc/v2ray-panel/node.json
 


### PR DESCRIPTION
First of all, thank you for your contributions.
Here I would like to apologize because the fix of #3 was a hurry. I found the problem during configuration but I forgot that the old node version was actually used during installation. Therefore, a fix is required so that the whole process uses node8 instead of system node.
I checked the script, and I found that the PATH was appended. To make sure, the node PATH should be inserted in front of every other PATH. 